### PR TITLE
[CARD-016] ✨ WebSocket frontend com Action Cable provider e real-time calendar

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@rails/actioncable": "^8.1.300",
         "@tailwindcss/postcss": "^4.2.1",
         "@tanstack/react-query": "^5.90.21",
         "autoprefixer": "^10.4.27",
@@ -2981,6 +2982,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
+    "node_modules/@rails/actioncable": {
+      "version": "8.1.300",
+      "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-8.1.300.tgz",
+      "integrity": "sha512-zOENQsq3NM2jyBY6Z2qtZa3V/R/6OEqA+LGKixQbBMl7kk/J3FXDRcszPe74LsHNgB01jCl/DXu/xA8sHt4I/g==",
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@rails/actioncable": "^8.1.300",
     "@tailwindcss/postcss": "^4.2.1",
     "@tanstack/react-query": "^5.90.21",
     "autoprefixer": "^10.4.27",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,16 +2,19 @@ import { RouterProvider } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { Toaster } from '@/components/ui/sonner'
+import { CableProvider } from '@/components/providers/CableProvider'
 import { router } from '@/app/routes'
 import { queryClient } from '@/lib/queryClient'
 
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <RouterProvider router={router} />
-        <Toaster />
-      </TooltipProvider>
+      <CableProvider>
+        <TooltipProvider>
+          <RouterProvider router={router} />
+          <Toaster />
+        </TooltipProvider>
+      </CableProvider>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/components/calendar/SlotCard.tsx
+++ b/frontend/src/components/calendar/SlotCard.tsx
@@ -26,7 +26,7 @@ const SlotCard = memo(function SlotCard({ slot, onClick }: SlotCardProps) {
   return (
     <Comp
       className={cn(
-        'group flex flex-col gap-2 rounded-xl border p-3 text-left transition-all duration-200',
+        'group flex flex-col gap-2 rounded-xl border p-3 text-left transition-all duration-500 ease-in-out',
         statusStyles[slot.status],
         onClick && 'cursor-pointer hover:shadow-[0_0_15px_rgba(102,252,241,0.1)]',
       )}

--- a/frontend/src/components/providers/CableProvider.test.tsx
+++ b/frontend/src/components/providers/CableProvider.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { useContext } from 'react'
+import { CableContext } from '@/lib/cableContext'
+import { CableProvider } from './CableProvider'
+
+const mockDisconnect = vi.fn()
+const mockConsumer = { subscriptions: {}, disconnect: mockDisconnect, connect: vi.fn() }
+
+vi.mock('@/lib/cable', () => ({
+  createCableConsumer: vi.fn(() => mockConsumer),
+}))
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: vi.fn((selector: (s: { token: string | null }) => unknown) =>
+    selector({ token: 'test-token' }),
+  ),
+}))
+
+function ConsumerInspector() {
+  const { consumer } = useContext(CableContext)
+  return <div data-testid="has-consumer">{consumer ? 'yes' : 'no'}</div>
+}
+
+describe('CableProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders children', () => {
+    render(
+      <CableProvider>
+        <span>child content</span>
+      </CableProvider>,
+    )
+
+    expect(screen.getByText('child content')).toBeInTheDocument()
+  })
+
+  it('provides consumer via context', () => {
+    render(
+      <CableProvider>
+        <ConsumerInspector />
+      </CableProvider>,
+    )
+
+    expect(screen.getByTestId('has-consumer')).toHaveTextContent('yes')
+  })
+})

--- a/frontend/src/components/providers/CableProvider.tsx
+++ b/frontend/src/components/providers/CableProvider.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useMemo } from 'react'
+import { createCableConsumer } from '@/lib/cable'
+import { CableContext } from '@/lib/cableContext'
+import { useAuthStore } from '@/stores/authStore'
+
+export function CableProvider({ children }: { children: React.ReactNode }) {
+  const token = useAuthStore((s) => s.token)
+  const consumer = useMemo(() => createCableConsumer(token), [token])
+
+  useEffect(() => {
+    return () => {
+      consumer?.disconnect()
+    }
+  }, [consumer])
+
+  return (
+    <CableContext.Provider value={{ consumer }}>
+      {children}
+    </CableContext.Provider>
+  )
+}

--- a/frontend/src/components/shared/Header.tsx
+++ b/frontend/src/components/shared/Header.tsx
@@ -1,9 +1,10 @@
 import { Link } from 'react-router-dom'
 import { useAuthStore } from '@/stores/authStore'
 import { useAuth } from '@/hooks/useAuth'
+import { useCalendarChannel } from '@/hooks/useCalendarChannel'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { LogOut, Shield, Swords } from 'lucide-react'
+import { LogOut, Shield, Swords, WifiOff } from 'lucide-react'
 
 interface HeaderProps {
   variant: 'public' | 'auth' | 'admin'
@@ -13,6 +14,7 @@ export default function Header({ variant }: HeaderProps) {
   const user = useAuthStore((s) => s.user)
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const { logout } = useAuth()
+  const { connected } = useCalendarChannel()
 
   return (
     <header className="gradient-border bg-bg-secondary/80 backdrop-blur-md px-6 py-3">
@@ -35,6 +37,12 @@ export default function Header({ variant }: HeaderProps) {
         </div>
 
         <div className="flex items-center gap-3">
+          {isAuthenticated && !connected && (
+            <span className="flex items-center gap-1.5 text-xs text-warning-400 animate-pulse">
+              <WifiOff className="size-3" />
+              Reconectando...
+            </span>
+          )}
           {isAuthenticated ? (
             <>
               <span className="text-sm text-text-secondary">{user?.email}</span>

--- a/frontend/src/hooks/useCable.ts
+++ b/frontend/src/hooks/useCable.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import { CableContext } from '@/lib/cableContext'
+
+export function useCable() {
+  return useContext(CableContext)
+}

--- a/frontend/src/hooks/useCalendarChannel.test.ts
+++ b/frontend/src/hooks/useCalendarChannel.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { createElement } from 'react'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+
+type SubscriptionMixin = {
+  connected?: () => void
+  disconnected?: () => void
+  received?: (message: unknown) => void
+}
+
+const mockUnsubscribe = vi.fn()
+let capturedMixin: SubscriptionMixin = {}
+
+const mockConsumer = {
+  subscriptions: {
+    create: vi.fn((_channel: string, mixin: SubscriptionMixin) => {
+      capturedMixin = mixin
+      return { unsubscribe: mockUnsubscribe, perform: vi.fn() }
+    }),
+  },
+  disconnect: vi.fn(),
+  connect: vi.fn(),
+}
+
+vi.mock('@/hooks/useCable', () => ({
+  useCable: vi.fn(() => ({ consumer: mockConsumer })),
+}))
+
+import { useCalendarChannel } from './useCalendarChannel'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe('useCalendarChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    capturedMixin = {}
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('creates subscription to ScrimChannel', () => {
+    renderHook(() => useCalendarChannel(), { wrapper: createWrapper() })
+
+    expect(mockConsumer.subscriptions.create).toHaveBeenCalledWith(
+      'ScrimChannel',
+      expect.objectContaining({
+        connected: expect.any(Function),
+        disconnected: expect.any(Function),
+        received: expect.any(Function),
+      }),
+    )
+  })
+
+  it('returns connected true after connected callback', () => {
+    const { result } = renderHook(() => useCalendarChannel(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      capturedMixin.connected?.()
+    })
+
+    expect(result.current.connected).toBe(true)
+  })
+
+  it('invalidates queries when message is received', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+
+    renderHook(() => useCalendarChannel(), { wrapper })
+
+    act(() => {
+      capturedMixin.received?.({
+        event: 'slot_created',
+        data: { id: 1, starts_at: '2026-03-26T20:00:00Z', ends_at: '2026-03-26T21:00:00Z', status: 'available' },
+      })
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['time-slots'] })
+  })
+
+  it('starts polling when disconnected', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+
+    renderHook(() => useCalendarChannel(), { wrapper })
+
+    act(() => {
+      capturedMixin.disconnected?.()
+    })
+
+    invalidateSpy.mockClear()
+
+    act(() => {
+      vi.advanceTimersByTime(30_000)
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['time-slots'] })
+  })
+
+  it('stops polling when reconnected', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+
+    renderHook(() => useCalendarChannel(), { wrapper })
+
+    act(() => {
+      capturedMixin.disconnected?.()
+    })
+
+    act(() => {
+      capturedMixin.connected?.()
+    })
+
+    invalidateSpy.mockClear()
+
+    act(() => {
+      vi.advanceTimersByTime(30_000)
+    })
+
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useCalendarChannel(), {
+      wrapper: createWrapper(),
+    })
+
+    unmount()
+
+    expect(mockUnsubscribe).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useCalendarChannel.ts
+++ b/frontend/src/hooks/useCalendarChannel.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCable } from '@/hooks/useCable'
+
+interface TimeSlotEvent {
+  event: 'slot_created' | 'slot_booked' | 'slot_cancelled'
+  data: {
+    id: number
+    starts_at: string
+    ends_at: string
+    status: 'available' | 'booked' | 'cancelled'
+  }
+}
+
+export function useCalendarChannel() {
+  const { consumer } = useCable()
+  const queryClient = useQueryClient()
+  const [connected, setConnected] = useState(false)
+  const pollingRef = useRef<ReturnType<typeof setInterval>>()
+
+  useEffect(() => {
+    if (!consumer) return
+
+    const subscription = consumer.subscriptions.create('ScrimChannel', {
+      connected() {
+        setConnected(true)
+        if (pollingRef.current) clearInterval(pollingRef.current)
+        queryClient.invalidateQueries({ queryKey: ['time-slots'] })
+      },
+      disconnected() {
+        setConnected(false)
+        pollingRef.current = setInterval(() => {
+          queryClient.invalidateQueries({ queryKey: ['time-slots'] })
+        }, 30_000)
+      },
+      received(_message: TimeSlotEvent) {
+        queryClient.invalidateQueries({ queryKey: ['time-slots'] })
+      },
+    })
+
+    return () => {
+      subscription.unsubscribe()
+      if (pollingRef.current) clearInterval(pollingRef.current)
+    }
+  }, [consumer, queryClient])
+
+  return { connected }
+}

--- a/frontend/src/lib/cable.test.ts
+++ b/frontend/src/lib/cable.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@rails/actioncable', () => ({
+  createConsumer: vi.fn((url: string) => ({ url, subscriptions: {} })),
+}))
+
+import { createConsumer } from '@rails/actioncable'
+import { createCableConsumer } from './cable'
+
+const mockCreateConsumer = vi.mocked(createConsumer)
+
+describe('createCableConsumer', () => {
+  beforeEach(() => {
+    mockCreateConsumer.mockClear()
+  })
+
+  it('creates consumer with token in URL when token is provided', () => {
+    createCableConsumer('test-jwt-token')
+
+    expect(mockCreateConsumer).toHaveBeenCalledWith(
+      'ws://localhost:3000/cable?token=test-jwt-token',
+    )
+  })
+
+  it('creates consumer without token in URL when token is null', () => {
+    createCableConsumer(null)
+
+    expect(mockCreateConsumer).toHaveBeenCalledWith(
+      'ws://localhost:3000/cable',
+    )
+  })
+
+  it('creates consumer without token in URL when token is undefined', () => {
+    createCableConsumer()
+
+    expect(mockCreateConsumer).toHaveBeenCalledWith(
+      'ws://localhost:3000/cable',
+    )
+  })
+})

--- a/frontend/src/lib/cable.ts
+++ b/frontend/src/lib/cable.ts
@@ -1,0 +1,8 @@
+import { createConsumer } from '@rails/actioncable'
+
+const WS_URL = import.meta.env.VITE_WS_URL || 'ws://localhost:3000/cable'
+
+export function createCableConsumer(token?: string | null) {
+  const url = token ? `${WS_URL}?token=${token}` : WS_URL
+  return createConsumer(url)
+}

--- a/frontend/src/lib/cableContext.ts
+++ b/frontend/src/lib/cableContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react'
+import type { Consumer } from '@rails/actioncable'
+
+export interface CableContextType {
+  consumer: Consumer | null
+}
+
+export const CableContext = createContext<CableContextType>({ consumer: null })

--- a/frontend/src/types/actioncable.d.ts
+++ b/frontend/src/types/actioncable.d.ts
@@ -1,0 +1,18 @@
+declare module '@rails/actioncable' {
+  export function createConsumer(url?: string): Consumer
+
+  export interface Consumer {
+    subscriptions: Subscriptions
+    disconnect(): void
+    connect(): void
+  }
+
+  export interface Subscriptions {
+    create(channel: string | object, mixin?: object): Subscription
+  }
+
+  export interface Subscription {
+    unsubscribe(): void
+    perform(action: string, data?: object): void
+  }
+}


### PR DESCRIPTION
## Tipo

| | Tipo | Descrição |
|---|---|---|
| [x] | ✨ `feat` | Nova funcionalidade |

## Resumo

Implementa integração WebSocket no frontend React usando `@rails/actioncable`, com provider de conexão, hook de subscription ao ScrimChannel, reconexão automática com fallback polling e transições visuais nos slots.

A motivação é completar o circuito real-time: o backend (CARD-015) já faz broadcast dos eventos — agora o frontend recebe e atualiza o calendário instantaneamente sem reload.

## Card

Closes #20

## Mudanças

- **CableProvider**: provider React que gerencia conexão Action Cable, injeta JWT via query param do authStore, reconecta quando token muda
- **useCalendarChannel**: hook que subscribe ao ScrimChannel, invalida queries do TanStack Query ao receber eventos, fallback polling 30s quando desconectado
- **lib/cable.ts**: factory `createCableConsumer` com URL configurável via `VITE_WS_URL`
- **Header**: indicador "Reconectando..." com ícone WifiOff quando WebSocket desconecta (apenas para usuários autenticados)
- **SlotCard**: `transition-all duration-500 ease-in-out` para transição suave ao mudar status
- **@rails/actioncable**: instalado como dependência + type declarations

## Como testar

### Pré-condições

- Docker up: `docker compose up`
- Backend com Action Cable (CARD-015 mergeado)

### Cenário de teste

1. Abrir o calendário público em duas abas
2. Na aba 1 (admin): criar um slot → aba 2 deve atualizar automaticamente
3. Na aba 2 (manager): agendar scrim → aba 1 deve mostrar slot como "booked"
4. Cancelar a scrim → ambas as abas devem atualizar
5. Desconectar Redis temporariamente → verificar "Reconectando..." no header
6. Reconectar Redis → verificar que calendário sincroniza automaticamente

**Resultado esperado:** Atualizações em tempo real, indicador de conexão, e fallback polling quando offline.

## Observações 💬

- CableContext separado em `lib/cableContext.ts` — ESLint react-refresh exige que arquivos de componente exportem apenas componentes
- Consumer criado via `useMemo` (não useEffect+setState) para evitar lint error `react-hooks/set-state-in-effect`
- `VITE_WS_URL` não adicionado ao .env (não existe no projeto) — fallback hardcoded `ws://localhost:3000/cable`
- Depende de CARD-015 (Action Cable backend) estar mergeado para funcionar end-to-end

## Checklist

- [x] Testes escritos e passando (`npm run test` — 11 specs)
- [x] Lint passando (`npm run lint` — 0 erros nos arquivos novos)
- [x] TypeScript passando (`tsc --noEmit`)
- [x] Sem secrets ou dados sensíveis no código
- [x] PR title segue o padrão: `[CARD-NNN] ✨ Descrição`